### PR TITLE
fix: correct allowed_pages syntax

### DIFF
--- a/index.php
+++ b/index.php
@@ -4,7 +4,7 @@
 $page = isset($_GET['page']) ? $_GET['page'] : 'home';
 
 $allowed_pages = [
-    'home'
+    'home',
     'login',
 ];
 


### PR DESCRIPTION
## Summary
- fix comma in PHP router allowed_pages array

## Testing
- `php -l index.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855a2ab4e58832f8ade9fb75b56c0f7